### PR TITLE
Change parameter misspelling in Index.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -142,7 +142,7 @@ CircularProgress.propTypes = {
   textStyle: PropTypes.object,
   maxValue: PropTypes.number,
   fontSize: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-  strokeLinecap: PropTypes.oneOf(['butt', 'round', 'sqaure']),
+  strokeLinecap: PropTypes.oneOf(['butt', 'round', 'square']),
   onAnimationComplete: PropTypes.func,
   valuePrefix: PropTypes.string,
   valueSuffix: PropTypes.string,


### PR DESCRIPTION
"Square" on line 145 for strokeLinecap is now spelled correctly