### PR TITLE
Build: 🏠 `3.2.0` - react-native-circular-progress-indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+###  Build: 🏠 `3.2.0` - react-native-circular-progress-indicator
+
+---
+- Added web support.
+- Now you can use the component in web too.
+
 ###  Build: 🏠 `3.1.0` - react-native-circular-progress-indicator
 
 ---

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # react-native-circular-progress-indicator
 
 [![license](https://img.shields.io/github/license/mashape/apistatus.svg)]()
-![platforms](https://img.shields.io/badge/platforms-Android%20%7C%20iOS-brightgreen.svg?style=flat&colorB=191A17)
+![platforms](https://img.shields.io/badge/platforms-Android%20%7C%20iOS%20%7C%20Web-brightgreen.svg?style=flat&colorB=191A17)
 [![Version](https://img.shields.io/npm/v/react-native-circular-progress-indicator.svg)](https://www.npmjs.com/package/react-native-circular-progress-indicator)
 [![npm](https://img.shields.io/npm/dt/react-native-circular-progress-indicator.svg)](https://www.npmjs.com/package/react-native-circular-progress-indicator)
 
@@ -10,7 +10,7 @@ A simple and customizable React Native circular progress indicator component.
 This project is inspired from this [Youtube tutorial](https://www.youtube.com/watch?v=x2LtzCxbWI0). Do check it out. Special mention at [@mironcatalin](https://www.youtube.com/channel/UCTcH04SRuyedaSuuQVeAcdg)
 ## Demo
 
-## ❤️ [Try on Expo Snack](https://snack.expo.dev/@nithinpp69/react-native-circular-progress-indicator/?platform=ios)
+## ❤️ [Try on Expo Snack](https://snack.expo.dev/@nithinpp69/react-native-circular-progress-indicator)
 
 ![](examples/demo.gif)
 ![](examples/demo2.gif)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-circular-progress-indicator",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "React Native customizable circular progress indicator",
   "main": "index",
   "scripts": {

--- a/src/circularProgress/index.tsx
+++ b/src/circularProgress/index.tsx
@@ -138,6 +138,7 @@ const CircularProgress: React.FC<CircularProgressProps> = ({
       >
         {showProgressValue && (
           <AnimatedInput
+            ref={inputRef}
             underlineColorAndroid={COLORS.TRANSPARENT}
             editable={false}
             defaultValue={`${valuePrefix}${initialValue}${valueSuffix}`}

--- a/src/circularProgress/index.tsx
+++ b/src/circularProgress/index.tsx
@@ -1,6 +1,6 @@
-import React, { useMemo } from 'react';
-import { Text, TextInput, StyleSheet, View } from 'react-native';
-import Animated from 'react-native-reanimated';
+import React, { useMemo, useRef } from 'react';
+import { Text, TextInput, StyleSheet, View, Platform } from 'react-native';
+import Animated, { useAnimatedReaction } from 'react-native-reanimated';
 import ProgressCircle from '../components/progressCircle';
 import useAnimatedValue from '../hooks/useAnimatedValue';
 import COLORS from '../utils/colors';
@@ -47,7 +47,11 @@ const CircularProgress: React.FC<CircularProgressProps> = ({
     return Math.round(v);
   },
 }: CircularProgressProps) => {
-  const { animatedCircleProps, animatedTextProps } = useAnimatedValue({
+  const {
+    animatedCircleProps,
+    animatedTextProps,
+    progressValue,
+  } = useAnimatedValue({
     initialValue,
     radius,
     maxValue,
@@ -60,6 +64,22 @@ const CircularProgress: React.FC<CircularProgressProps> = ({
     progressFormatter,
     valueSuffix,
   });
+
+  const inputRef = useRef<any>(null);
+
+  if (Platform.OS === 'web') {
+    // only run the reaction on web platform.
+    useAnimatedReaction(
+      () => {
+        return progressValue.value;
+      },
+      (data, prevData) => {
+        if (data !== prevData && inputRef.current) {
+          inputRef.current.value = data;
+        }
+      }
+    );
+  }
 
   const styleProps = useMemo(
     () => ({
@@ -118,7 +138,7 @@ const CircularProgress: React.FC<CircularProgressProps> = ({
       >
         {showProgressValue && (
           <AnimatedInput
-            underlineColorAndroid="transparent"
+            underlineColorAndroid={COLORS.TRANSPARENT}
             editable={false}
             defaultValue={`${valuePrefix}${initialValue}${valueSuffix}`}
             style={[

--- a/src/components/progressCircle/index.tsx
+++ b/src/components/progressCircle/index.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import Svg, { G, Circle, Defs, LinearGradient, Stop } from 'react-native-svg';
 import Animated from 'react-native-reanimated';
 import COLORS from '../..//utils/colors';
+import styles from './styles';
 import { ProgressCircleProps } from './types';
 
 const AnimatedCircle = Animated.createAnimatedComponent(Circle);
@@ -29,6 +30,7 @@ const ProgressCircle: React.FC<ProgressCircleProps> = ({
       width={radius * 2}
       height={radius * 2}
       viewBox={`0 0 ${viewBox * 2} ${viewBox * 2}`}
+      style={styles.svg}
     >
       {activeStrokeSecondaryColor ? (
         <Defs>
@@ -38,7 +40,7 @@ const ProgressCircle: React.FC<ProgressCircleProps> = ({
           </LinearGradient>
         </Defs>
       ) : null}
-      <G rotation="270" origin={`${viewBox}, ${viewBox}`}>
+      <G origin={`${viewBox}, ${viewBox}`}>
         <Circle
           cx="50%"
           cy="50%"
@@ -54,7 +56,7 @@ const ProgressCircle: React.FC<ProgressCircleProps> = ({
           stroke={activeStrokeSecondaryColor ? 'url(#grad)' : activeStrokeColor}
           strokeWidth={activeStrokeWidth}
           r={radius}
-          fill="transparent"
+          fill={COLORS.TRANSPARENT}
           strokeDasharray={circleCircumference}
           strokeLinecap={strokeLinecap}
           animatedProps={animatedCircleProps}

--- a/src/components/progressCircle/styles.ts
+++ b/src/components/progressCircle/styles.ts
@@ -1,0 +1,7 @@
+import { StyleSheet } from 'react-native';
+
+const styles = StyleSheet.create({
+  svg: { transform: [{ rotateZ: '270deg' }] },
+});
+
+export default styles;

--- a/src/hooks/useAnimatedValue.ts
+++ b/src/hooks/useAnimatedValue.ts
@@ -9,7 +9,7 @@ import {
   withTiming,
 } from 'react-native-reanimated';
 
-export interface useAnimatedValueProps {
+export interface UseAnimatedValueProps {
   value: number;
   initialValue?: number;
   radius?: number;
@@ -39,7 +39,7 @@ export default function useAnimatedValue({
     return Math.round(v);
   },
   valueSuffix = '',
-}: useAnimatedValueProps) {
+}: UseAnimatedValueProps) {
   const animatedValue = useSharedValue(initialValue);
   const circleCircumference = useMemo(() => 2 * Math.PI * radius, [radius]);
 
@@ -81,5 +81,6 @@ export default function useAnimatedValue({
   return {
     animatedCircleProps,
     animatedTextProps,
+    progressValue,
   };
 }


### PR DESCRIPTION
Build: 🏠 `3.2.0` - react-native-circular-progress-indicator


- Added web support.
- Now you can use the component in web too.